### PR TITLE
Escape comma in filename

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -25,7 +25,8 @@ export function buildRequestUrl(
 			.replaceAll(":", "%3A") // See: https://github.com/nikeee/lean-s3/issues/61
 			.replaceAll("+", "%2B")
 			.replaceAll("(", "%28")
-			.replaceAll(")", "%29");
+			.replaceAll(")", "%29")
+			.replaceAll(",", "%2C");
 
 	return result;
 }


### PR DESCRIPTION
Was unable to handle files with comma in the filename. Had to add escape for comma.